### PR TITLE
add screen to apt all, update forever script with correct path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ any environment that matters.
 Start with a clean install of [Raspberry Pi OS Lite 64bit](https://www.raspberrypi.com/software/operating-systems/), then `apt` install a bunch of stuff, clone the repo, `cd` into it and set up a python virtual envorinment, activate it and install python requirements with the following code: 
 
 ```
-sudo apt install -y git python3-picamera2     # From https://pypi.org/project/picamera2/ - installs a LOT - be patient!
+sudo apt install -y git screen python3-picamera2     # From https://pypi.org/project/picamera2/ - installs a LOT - be patient!
 git clone https://github.com/NegativeK/picamserver.git
 cd picamserver
 python3 -m venv --system-site-packages venv # From https://forums.raspberrypi.com/viewtopic.php?t=361758

--- a/forever.sh
+++ b/forever.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-cd ~/camserver
+cd ~/picamserver
 screen ./run.sh


### PR DESCRIPTION
this pr:
* adds `screen` to the `apt install` call as we use in the bash script
* updates the `forever.sh` to use the same directory name as the repo so that it works ;)