### PR TITLE
Add services files and service file install script, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,24 @@ assumes a Raspberry Pi and is intended to work on Raspbian, so it uses the apt
 packages.
 
 # Running
-`bash forever.sh`
 
-forever.sh runs the flask server in a screen session. If the server dies, it's
-forcibly restarted. Hit ctrl+c a lot in the screen session to kill it. The
-server will die if there are simultaneous requests against the camera. (I 
-warned you that this is gross.)
+To start services and have them run at boot, call: 
+
+`bash install.service.sh`
+
+After calling this script, to start, stop and restart the services:
+
+```shell
+# IMAGE SERVER
+sudo systemctl start picamserver-image
+sudo systemctl stop picamserver-image
+sudo systemctl status picamserver-image
+
+# WEB SERVER
+sudo systemctl start picamserver-web
+sudo systemctl stop picamserver-web
+sudo systemctl status picamserver-web
+```
 
 # Configuration
 Defaults:
@@ -67,4 +79,12 @@ This will enable the virtualenv and run:
 ```
 ruff check
 mypy *.py
+```
+
+To see logs:
+
+```shell
+journalctl --follow --unit picamserver-\*     # tail both
+journalctl --follow --unit picamserver-image  # tail just image server
+journalctl --follow --unit picamserver-web    # tail just web server
 ```

--- a/install.service.sh
+++ b/install.service.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -e
+
+directory=$(pwd)
+user=$(echo $USER)
+
+read -p "
+-------------------------------------------------------
+Press 'Enter' if your user has 'sudo' and you're ready to install the Picamserver services to start at boot.
+
+Press 'ctrl + c' if you don't want continue.
+
+Using directory '${directory}' with user '${user}' for install.
+" </dev/tty
+
+echo "
+-------------------------------------------------------
+Installing...
+
+(be patient - this might take a sec!)
+"
+
+sudo cp picamserver-image.service /etc/systemd/system/
+sudo cp picamserver-web.service /etc/systemd/system/
+sudo sed -i "s|WORK_DIR|${directory}|g" /etc/systemd/system/picamserver-image.service
+sudo sed -i "s|WORK_DIR|${directory}|g" /etc/systemd/system/picamserver-web.service
+sudo sed -i "s|USER|${user}|g" /etc/systemd/system/picamserver-web.service
+sudo sed -i "s|USER|${user}|g" /etc/systemd/system/picamserver-image.service
+sudo systemctl daemon-reload
+sudo systemctl enable picamserver-web
+sudo systemctl start picamserver-web
+sudo systemctl enable picamserver-image
+sudo systemctl start picamserver-image
+
+
+echo "
+-------------------------------------------------------
+Install complete! run these commands as needed:
+
+IMAGE SERVER
+sudo systemctl start picamserver-image
+sudo systemctl stop picamserver-image
+sudo systemctl status picamserver-image
+
+WEB SERVER
+sudo systemctl start picamserver-web
+sudo systemctl stop picamserver-web
+sudo systemctl status picamserver-web
+
+WATCHING LOGS:
+journalctl --follow --unit picamserver-\*     # tail both
+journalctl --follow --unit picamserver-image  # tail just image server
+journalctl --follow --unit picamserver-web    # tail just web server
+
+"

--- a/install.service.sh
+++ b/install.service.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# this script assumes you're:
+#   - running it from the `picamserver` repo root repository directory
+#   - logged in as the user you want to run the service as
+#   - the user you're logged in as has `sudo` permissions
+
 set -e
 
 directory=$(pwd)

--- a/install.service.sh
+++ b/install.service.sh
@@ -7,8 +7,8 @@
 
 set -e
 
-directory=$(pwd)
-user=$(echo $USER)
+directory=$PWD
+user=$USER
 
 read -p "
 -------------------------------------------------------
@@ -59,3 +59,4 @@ journalctl --follow --unit picamserver-image  # tail just image server
 journalctl --follow --unit picamserver-web    # tail just web server
 
 "
+

--- a/picamserver-image.service
+++ b/picamserver-image.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Picamserver Image
+After=network.target
+
+[Service]
+Type=simple
+User=USER
+WorkingDirectory=WORK_DIR
+ExecStart=/usr/bin/python camdaemon.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/picamserver-web.service
+++ b/picamserver-web.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Picamserver Web
+After=network.target
+
+[Service]
+Type=simple
+User=USER
+WorkingDirectory=WORK_DIR
+ExecStart=/usr/bin/python -m flask --app main run -h 0.0.0.0 --reload
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Changes

* adds two `*.service` files
* updates readme with install steps
* adds bash script `install.service.sh` so there's no hard coded paths 
* closes #10 

## To test

* `cd` into the `picamserver` directory
* check out `10-autorun-at-boot` branch
* run `bash install.service.sh`
* follow instructions
* reboot your pi, make sure everything starts up at boot as expected