### PR TITLE
make page load instantly, simplify JS

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,12 +15,12 @@
 	const loadingDiv = document.querySelector(".loadingStatus");
 	const cameraFeed = document.querySelector(".cameraFeed");
 
-	function refreshImage(imgURL) {
-		time = new Date().getTime();
-		cameraFeed.src = imgURL + "?" + time;
+    function refreshImage(imgURL) {
+		const time = new Date().getTime().toString();
+		cameraFeed.src = "./printer?" + time;
 		loadingDiv.innerHTML = time;
 	}
-
-	setInterval(refreshImage, 5000, image_path);
+	refreshImage();
+	setInterval(refreshImage, 5000);
 </script>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,13 +11,12 @@
 	<div class="loadingStatus">Loading...</div>
 </body>
 <script>
-	const image_path = "{{ image }}";
 	const loadingDiv = document.querySelector(".loadingStatus");
 	const cameraFeed = document.querySelector(".cameraFeed");
 
 	function refreshImage(imgURL) {
 		const time = new Date().getTime().toString();
-		cameraFeed.src = "./printer?" + time;
+		cameraFeed.src = "{{ image }}?" + time;
 		loadingDiv.innerHTML = time;
 	}
 	refreshImage();

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
 	const loadingDiv = document.querySelector(".loadingStatus");
 	const cameraFeed = document.querySelector(".cameraFeed");
 
-    function refreshImage(imgURL) {
+	function refreshImage(imgURL) {
 		const time = new Date().getTime().toString();
 		cameraFeed.src = "./printer?" + time;
 		loadingDiv.innerHTML = time;


### PR DESCRIPTION
This PR:
* reduces the number of JS lines by collapsing a variable or two
* calls `refreshImage()` before `setIngerval()` so page loads instantly instead of waiting `5000`ms
* still feels just as legible to me, but open to feedback!